### PR TITLE
Fix non-float error

### DIFF
--- a/nut-influxdb-exporter.py
+++ b/nut-influxdb-exporter.py
@@ -81,7 +81,7 @@ def construct_object(data, remove_keys, tag_keys):
             else:
                 fields[k] = convert_to_type(v)
 
-    watts = nut_watts if nut_watts else fields['ups.realpower.nominal']
+    watts = float(nut_watts) if nut_watts else float(fields['ups.realpower.nominal'])
     fields['watts'] = watts * 0.01 * fields['ups.load']
 
     result = [


### PR DESCRIPTION
I was getting an error, stating:
```
File "/src/nut-influxdb-exporter.py", line 107, in <module>
json_body = construct_object(ups_data, remove_keys, tag_keys)
File "/src/nut-influxdb-exporter.py", line 85, in construct_object
fields['watts'] = watts * 0.01 * fields['ups.load']
TypeError: can't multiply sequence by non-int of type 'float'
```
I fixed this by adding a float-conversion to the watts value