### PR TITLE
Update nut-influxdb-exporter.py

### DIFF
--- a/nut-influxdb-exporter.py
+++ b/nut-influxdb-exporter.py
@@ -52,14 +52,10 @@ if ups_client:
 def convert_to_type(s):
     """ A function to convert a str to either integer or float. If neither, it will return the str. """
     try:
-        int_var = int(s)
-        return int_var
+        float_var = float(s)
+        return float_var
     except ValueError:
-        try:
-            float_var = float(s)
-            return float_var
-        except ValueError:
-            return s
+        return s
 
 
 def construct_object(data, remove_keys, tag_keys):


### PR DESCRIPTION
Update the convert function to just try casting to float - InfluxDB assumes a float by default, and further I have used multiple NUT instances where some are an INT others a FLOAT causing casting error because InfluxDBClient specifically supplies 'i' in the write function for INTs.

It should resolve errors such as this:
influxdb.exceptions.InfluxDBClientError: 400: {"error":"partial write: field type conflict: input field \"input.voltage\" on measurement \"ups_status\" is type integer, already exists as type float dropped=1"}